### PR TITLE
Update GAMS<->cuopt link for new cuopt release v26.06 cuopt-release

### DIFF
--- a/.github/workflows/main-arm64.yml
+++ b/.github/workflows/main-arm64.yml
@@ -29,12 +29,12 @@ jobs:
           python -m venv venvs/cu12
           bash -c "source venvs/cu12/bin/activate && \
             pip install --upgrade pip -qq && \
-            pip install --timeout=150 --extra-index-url=https://pypi.nvidia.com cuopt-cu12==26.4.* -qq &&
+            pip install --timeout=150 --extra-index-url=https://pypi.nvidia.com 'cuopt-cu12==26.6.*' -qq &&
             deactivate"
           python -m venv venvs/cu13
           bash -c "source venvs/cu13/bin/activate && \
             pip install --upgrade pip -qq && \
-            pip install --timeout=150 --extra-index-url=https://pypi.nvidia.com cuopt-cu13==26.4.* -qq &&
+            pip install --timeout=150 --extra-index-url=https://pypi.nvidia.com 'cuopt-cu13==26.6.*' -qq &&
             deactivate"
 
       # Get GAMS (ARM64 version)

--- a/.github/workflows/main-arm64.yml
+++ b/.github/workflows/main-arm64.yml
@@ -75,7 +75,6 @@ jobs:
           cp gmscuopt-cu12.out release-cu12/gmscuopt.out
           cp assets/* release-cu12/
           cp venvs/cu12/lib/python3.12/site-packages/libcuopt/lib64/libcuopt.so release-cu12/
-          cp venvs/cu12/lib/python3.12/site-packages/libcuopt/lib64/libmps_parser.so release-cu12/
           cp venvs/cu12/lib/python3.12/site-packages/libcuopt_cu12.libs/libgomp-*.so.1.0.0 release-cu12/
           cp venvs/cu12/lib/python3.12/site-packages/libcuopt_cu12.libs/libtbb-*.so.2 release-cu12/
           cp venvs/cu12/lib/python3.12/site-packages/libcuopt_cu12.libs/libtbbmalloc-*.so.2 release-cu12/
@@ -90,14 +89,11 @@ jobs:
           cp venvs/cu12/lib/python3.12/site-packages/nvidia/nvjitlink/lib/libnvJitLink.so.12 runtime-cu12/
           cp venvs/cu12/lib/python3.12/site-packages/nvidia/curand/lib/libcurand.so.10 runtime-cu12/
           cp venvs/cu12/lib/python3.12/site-packages/nvidia/cusparse/lib/libcusparse.so.12 runtime-cu12/
-          cp venvs/cu12/lib/python3.12/site-packages/libcuopt_cu12.libs/libssl-*.so.1.1.1k runtime-cu12/
           cp venvs/cu12/lib/python3.12/site-packages/libcuopt_cu12.libs/libcares-*.so.2.2.0 runtime-cu12/
-          cp venvs/cu12/lib/python3.12/site-packages/libcuopt_cu12.libs/libcrypto-*.so.1.1.1k runtime-cu12/
           mkdir release-cu13
           cp gmscuopt-cu13.out release-cu13/gmscuopt.out
           cp assets/* release-cu13/
           cp venvs/cu13/lib/python3.12/site-packages/libcuopt/lib64/libcuopt.so release-cu13/
-          cp venvs/cu13/lib/python3.12/site-packages/libcuopt/lib64/libmps_parser.so release-cu13/
           cp venvs/cu13/lib/python3.12/site-packages/libcuopt_cu13.libs/libgomp-*.so.1.0.0 release-cu13/
           cp venvs/cu13/lib/python3.12/site-packages/libcuopt_cu13.libs/libtbb-*.so.2 release-cu13/
           cp venvs/cu13/lib/python3.12/site-packages/libcuopt_cu13.libs/libtbbmalloc-*.so.2 release-cu13/
@@ -112,9 +108,7 @@ jobs:
           cp venvs/cu13/lib/python3.12/site-packages/nvidia/cu13/lib/libcurand.so.10 runtime-cu13/
           cp venvs/cu13/lib/python3.12/site-packages/nvidia/cu13/lib/libcusolver.so.12 runtime-cu13/
           cp venvs/cu13/lib/python3.12/site-packages/nvidia/cu13/lib/libcusparse.so.12 runtime-cu13/
-          cp venvs/cu13/lib/python3.12/site-packages/libcuopt_cu13.libs/libssl-*.so.1.1.1k runtime-cu13/
           cp venvs/cu13/lib/python3.12/site-packages/libcuopt_cu13.libs/libcares-*.so.2.2.0 runtime-cu13/
-          cp venvs/cu13/lib/python3.12/site-packages/libcuopt_cu13.libs/libcrypto-*.so.1.1.1k runtime-cu13/
 
       # Upload artifacts
       - name: Upload CUDA 12 link artifact to GitHub Actions (always)

--- a/.github/workflows/main-x86_64.yml
+++ b/.github/workflows/main-x86_64.yml
@@ -29,12 +29,12 @@ jobs:
           python -m venv venvs/cu12
           bash -c "source venvs/cu12/bin/activate && \
             pip install --upgrade pip -qq && \
-            pip install --timeout=150 --extra-index-url=https://pypi.nvidia.com cuopt-cu12==26.4.* -qq &&
+            pip install --timeout=150 --extra-index-url=https://pypi.nvidia.com 'cuopt-cu12==26.6.*' -qq &&
             deactivate"
           python -m venv venvs/cu13
           bash -c "source venvs/cu13/bin/activate && \
             pip install --upgrade pip -qq && \
-            pip install --timeout=150 --extra-index-url=https://pypi.nvidia.com cuopt-cu13==26.4.* -qq &&
+            pip install --timeout=150 --extra-index-url=https://pypi.nvidia.com 'cuopt-cu13==26.6.*' -qq &&
             deactivate"
 
       # Get GAMS

--- a/.github/workflows/main-x86_64.yml
+++ b/.github/workflows/main-x86_64.yml
@@ -75,7 +75,6 @@ jobs:
           cp gmscuopt-cu12.out release-cu12/gmscuopt.out
           cp assets/* release-cu12/
           cp venvs/cu12/lib/python3.12/site-packages/libcuopt/lib64/libcuopt.so release-cu12/
-          cp venvs/cu12/lib/python3.12/site-packages/libcuopt/lib64/libmps_parser.so release-cu12/
           cp venvs/cu12/lib/python3.12/site-packages/libcuopt_cu12.libs/libgomp-*.so.1.0.0 release-cu12/
           cp venvs/cu12/lib/python3.12/site-packages/libcuopt_cu12.libs/libtbb-*.so.2 release-cu12/
           cp venvs/cu12/lib/python3.12/site-packages/libcuopt_cu12.libs/libtbbmalloc-*.so.2 release-cu12/
@@ -90,14 +89,11 @@ jobs:
           cp venvs/cu12/lib/python3.12/site-packages/nvidia/nvjitlink/lib/libnvJitLink.so.12 runtime-cu12/
           cp venvs/cu12/lib/python3.12/site-packages/nvidia/curand/lib/libcurand.so.10 runtime-cu12/
           cp venvs/cu12/lib/python3.12/site-packages/nvidia/cusparse/lib/libcusparse.so.12 runtime-cu12/
-          cp venvs/cu12/lib/python3.12/site-packages/libcuopt_cu12.libs/libssl-*.so.1.1.1k runtime-cu12/
           cp venvs/cu12/lib/python3.12/site-packages/libcuopt_cu12.libs/libcares-*.so.2.2.0 runtime-cu12/
-          cp venvs/cu12/lib/python3.12/site-packages/libcuopt_cu12.libs/libcrypto-*.so.1.1.1k runtime-cu12/
           mkdir release-cu13
           cp gmscuopt-cu13.out release-cu13/gmscuopt.out
           cp assets/* release-cu13/
           cp venvs/cu13/lib/python3.12/site-packages/libcuopt/lib64/libcuopt.so release-cu13/
-          cp venvs/cu13/lib/python3.12/site-packages/libcuopt/lib64/libmps_parser.so release-cu13/
           cp venvs/cu13/lib/python3.12/site-packages/libcuopt_cu13.libs/libgomp-*.so.1.0.0 release-cu13/
           cp venvs/cu13/lib/python3.12/site-packages/libcuopt_cu13.libs/libtbb-*.so.2 release-cu13/
           cp venvs/cu13/lib/python3.12/site-packages/libcuopt_cu13.libs/libtbbmalloc-*.so.2 release-cu13/
@@ -112,9 +108,7 @@ jobs:
           cp venvs/cu13/lib/python3.12/site-packages/nvidia/cu13/lib/libcurand.so.10 runtime-cu13/
           cp venvs/cu13/lib/python3.12/site-packages/nvidia/cu13/lib/libcusolver.so.12 runtime-cu13/
           cp venvs/cu13/lib/python3.12/site-packages/nvidia/cu13/lib/libcusparse.so.12 runtime-cu13/
-          cp venvs/cu13/lib/python3.12/site-packages/libcuopt_cu13.libs/libssl-*.so.1.1.1k runtime-cu13/
           cp venvs/cu13/lib/python3.12/site-packages/libcuopt_cu13.libs/libcares-*.so.2.2.0 runtime-cu13/
-          cp venvs/cu13/lib/python3.12/site-packages/libcuopt_cu13.libs/libcrypto-*.so.1.1.1k runtime-cu13/
 
       # Upload artifacts
       - name: Upload CUDA 12 link artifact to GitHub Actions (always)

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
 .vscode/
 /venv/*
 /release/*
-*.gms
 *.lst
 *.out
-cuopt.opt
 /examples/cu*runtime.zip
 /examples/cuopt-link-release-cu*.zip

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This project builds and packages the [GAMS](https://gams.com/) and [GAMSPy](http
 
 You can get more details and tips by reading the blog post ["GPU-Accelerated Optimization with GAMS and NVIDIA cuOpt"](https://www.gams.com/blog/2025/09/gpu-accelerated-optimization-with-gams-and-nvidia-cuopt/).
 
+Supported model types are LP, MIP, RMIP, QCP, MIQCP, RMIQCP.
+
 ## Requirements
 
 - **Operating System:** Linux, Windows 11 through WSL2
@@ -34,5 +36,11 @@ gams trnsport lp cuopt
 
 ## Examples
 
+### Notebooks
+
 - [examples/trnsport_cuopt.ipynb](examples/trnsport_cuopt.ipynb) for CUDA 12 on x86_64
 - [examples/trnsport_cuopt.ipynb](examples/trnsport_cuopt_cu13.ipynb) for CUDA 13 on x86_64
+
+### GAMS models
+
+Various GAMS models can be found in subfolder `examples/models` and are used to verify the solver link.

--- a/assets/gamsconfig.yaml
+++ b/assets/gamsconfig.yaml
@@ -10,3 +10,4 @@ solverConfig:
         - LP
         - RMIP
         - MIP
+        - QCP

--- a/assets/gamsconfig.yaml
+++ b/assets/gamsconfig.yaml
@@ -11,3 +11,5 @@ solverConfig:
         - RMIP
         - MIP
         - QCP
+        - MIQCP
+        - RMIQCP

--- a/assets/optcuopt.def
+++ b/assets/optcuopt.def
@@ -9,8 +9,10 @@ presolve enumint 0 -1 1 1 Controls which presolver (if any) to use for presolve 
   0 1 off (disable presolve)
   1 1 papilo
   2 1 pslp
+mip_probing
 dual_postsolve boolean 0 0 1 2 Controls whether dual postsolve is enabled when using Papilo presolver for LP problems. Enabled by default for LP when Papilo presolve is selected.
 time_limit integer 0 maxint 0 maxint 1 1 Controls the time limit in seconds after which the solver will stop and return the current solution (default GAMS ResLim)
+node_limit
 prob_read string 1 "" 1 1 Reads a problem from an MPS file 
 pdlp_solver_mode enumint 0 4 1 2 Controls the mode under which PDLP should operate
  0 1 stable1 First obsolete legacy predecessor of stable3
@@ -57,6 +59,8 @@ barrier_dual_initial_point enumint 0 -1 1 4 Controls the method used to compute 
  -1 1 automatic (default) cuOpt selects the best method
  0 1 use an initial point from a heuristic approach based on the paper "On Implementing Mehrotra’s Predictor–Corrector Interior-Point Method for Linear Programming" (SIAM J. Optimization, 1992) by Lustig, Martsten, Shanno.
  1 1 use an initial point from solving a least squares problem that minimizes the norms of the dual variables and reduced costs while statisfying the dual equality constraints.
+barrier_iterative_refinement
+barrier_step_scale
 absolute_primal_tolerance double 0 0.0001 0 maxdouble 1 2 Controls the absolute primal tolerance used in PDLP's primal feasibility check
 relative_primal_tolerance double 0 0.0001 0 maxdouble 1 2 Controls the relative primal tolerance used in PDLP's primal feasibility check
 absolute_dual_tolerance double 0 0.0001 0 maxdouble 1 2 Controls the absolute dual tolerance used in PDLP's dual feasibility check
@@ -67,11 +71,12 @@ primal_infeasible_tolerance double 0 1e-08 0 maxdouble 0 2 Unknown
 dual_infeasible_tolerance double 0 1e-08 0 maxdouble 0 2 Unknown
 miptrace string 0 "" 1 3 filename of MIP trace file which logs the best found (incumbent) and best bound over time
 mipstart boolean -1 0 1 3 whether it should be tried to use the initial variable levels as initial MIP solution
-mip_heuristics_only boolean 0 0 1 3 Controls if only the GPU heuristics should be run       
+mip_heuristics_only boolean 0 0 1 3 Controls if only the GPU heuristics should be run
 mip_scaling enumint 0 1 1 3 Controls if scaling should be applied to the MIP problem
  0 1 no scaling
  1 1 full scaling (objective + row), default
  2 1 row scaling only (no objective scaling)
+mip_symmetry
 mip_absolute_tolerance double 0 0.0001 0 maxdouble 1 3 Controls the MIP absolute tolerance
 mip_relative_tolerance double 0 0.0001 0 maxdouble 1 3 Controls the MIP relative tolerance
 mip_integrality_tolerance double 0 1e-05 0 maxdouble 1 3 Controls the MIP integrality tolerance
@@ -82,8 +87,10 @@ mip_mixed_integer_rounding_cuts integer 0 -1 -1 1 1 3 Controls whether to use mi
 mip_mixed_integer_gomory_cuts integer 0 -1 -1 1 1 3 Controls whether to use mixed integer Gomory cuts
 mip_strong_chvatal_gomory_cuts integer 0 -1 -1 1 1 3 Controls whether to use strong Chvatal-Gomory cuts
 mip_knapsack_cuts integer 0 -1 -1 1 1 3 Controls whether to use knapsack cuts
+mip_flow_cover_cuts
 mip_implied_bound_cuts integer 0 -1 -1 1 1 3 Controls whether to enable implied bound cuts (-1 auto/default, 0 off, >0 on)
 mip_clique_cuts integer 0 -1 -1 1 1 3 Controls whether to enable clique cuts (-1 auto/default, 0 off, >0 on).
+mip_objective_step boolean 0 0 1 3 Controls whether cuOpt automatically detects and exploits discrete step structure in objective to tighten dual bound (0 off, 1 on/default).
 mip_cut_change_threshold double 0 1e-03 0 maxdouble 1 3 Controls the threshold for the improvement in the dual bound per cut pass
 mip_cut_min_orthogonality double 0 0.5 0 maxdouble 1 3 Controls the minimum orthogonality required for a cut to be added to the LP relaxation
 mip_reduced_cost_strengthening integer 0 -1 -1 2 1 3 Controls whether to use reduced-cost strengthening
@@ -106,6 +113,19 @@ mip_hyper_heuristic_enabled_recombiners integer 0 15 0 maxint 1 3 Controls bitma
 mip_hyper_heuristic_cycle_detection_length integer 0 30 0 maxint 1 3 Controls FP assignment cycle ring buffer
 mip_hyper_heuristic_relaxed_lp_time_limit double 0 1 0 maxdouble 1 3 Controls base relaxed LP time cap in heuristics
 mip_hyper_heuristic_related_vars_time_limit double 0 30 0 maxdouble 1 3 Controls time for related-variable structure build
+mip_hyper_diving_line_search
+mip_hyper_diving_pseudocost
+mip_hyper_diving_guided
+mip_hyper_diving_coefficient
+mip_hyper_diving_farkas
+mip_hyper_diving_vector_length
+mip_hyper_diving_min_node_depth
+mip_hyper_diving_node_limit
+mip_hyper_diving_iteration_limit_factor
+mip_hyper_diving_backtrack_limit
+mip_hyper_diving_show_type
+mip_semicontinuous_big_m double 0 0 0 maxdouble 1 3 Controls the Big-M coefficient used when linearizing semi-continuous variable constraints
+
 *
 * Groups
 *

--- a/assets/optcuopt.def
+++ b/assets/optcuopt.def
@@ -9,10 +9,10 @@ presolve enumint 0 -1 1 1 Controls which presolver (if any) to use for presolve 
   0 1 off (disable presolve)
   1 1 papilo
   2 1 pslp
-mip_probing
+mip_probing boolean 0 1 1 1 Toggles the probing-cache step of cuOpt's internal MIP presolve.
 dual_postsolve boolean 0 0 1 2 Controls whether dual postsolve is enabled when using Papilo presolver for LP problems. Enabled by default for LP when Papilo presolve is selected.
 time_limit integer 0 maxint 0 maxint 1 1 Controls the time limit in seconds after which the solver will stop and return the current solution (default GAMS ResLim)
-node_limit
+node_limit integer 0 maxint 0 maxint 1 1 Controls the maximum number of branch-and-bound nodes the MILP solver will explore before stopping and returning the current best feasible solution (if any).
 prob_read string 1 "" 1 1 Reads a problem from an MPS file 
 pdlp_solver_mode enumint 0 4 1 2 Controls the mode under which PDLP should operate
  0 1 stable1 First obsolete legacy predecessor of stable3
@@ -59,8 +59,8 @@ barrier_dual_initial_point enumint 0 -1 1 4 Controls the method used to compute 
  -1 1 automatic (default) cuOpt selects the best method
  0 1 use an initial point from a heuristic approach based on the paper "On Implementing Mehrotra’s Predictor–Corrector Interior-Point Method for Linear Programming" (SIAM J. Optimization, 1992) by Lustig, Martsten, Shanno.
  1 1 use an initial point from solving a least squares problem that minimizes the norms of the dual variables and reduced costs while statisfying the dual equality constraints.
-barrier_iterative_refinement
-barrier_step_scale
+barrier_iterative_refinement boolean 0 1 1 4 Controls whether iterative refinement is applied after each barrier iteration to improve solution accuracy.
+barrier_step_scale double 0 0.9 0.5 0.9999 1 4 Controls the scaling factor applied to the step size in the barrier method.
 absolute_primal_tolerance double 0 0.0001 0 maxdouble 1 2 Controls the absolute primal tolerance used in PDLP's primal feasibility check
 relative_primal_tolerance double 0 0.0001 0 maxdouble 1 2 Controls the relative primal tolerance used in PDLP's primal feasibility check
 absolute_dual_tolerance double 0 0.0001 0 maxdouble 1 2 Controls the absolute dual tolerance used in PDLP's dual feasibility check
@@ -76,7 +76,11 @@ mip_scaling enumint 0 1 1 3 Controls if scaling should be applied to the MIP pro
  0 1 no scaling
  1 1 full scaling (objective + row), default
  2 1 row scaling only (no objective scaling)
-mip_symmetry
+mip_symmetry enumint 0 -1 1 3 Controls symmetry detection and handling in the MIP solver.
+ -1 1 automatic (default) cuOpt decides based on problem characteristics.
+ 0 1 disables symmetry handling.
+ 1 1 enable symmetry handling (orbital fixing only)
+ 2 1 enable symmetry handling (orbital fixing + lexical reduction)
 mip_absolute_tolerance double 0 0.0001 0 maxdouble 1 3 Controls the MIP absolute tolerance
 mip_relative_tolerance double 0 0.0001 0 maxdouble 1 3 Controls the MIP relative tolerance
 mip_integrality_tolerance double 0 1e-05 0 maxdouble 1 3 Controls the MIP integrality tolerance
@@ -87,7 +91,10 @@ mip_mixed_integer_rounding_cuts integer 0 -1 -1 1 1 3 Controls whether to use mi
 mip_mixed_integer_gomory_cuts integer 0 -1 -1 1 1 3 Controls whether to use mixed integer Gomory cuts
 mip_strong_chvatal_gomory_cuts integer 0 -1 -1 1 1 3 Controls whether to use strong Chvatal-Gomory cuts
 mip_knapsack_cuts integer 0 -1 -1 1 1 3 Controls whether to use knapsack cuts
-mip_flow_cover_cuts
+mip_flow_cover_cuts enumint 0 -1 1 3 Controls whether to use flow cover cuts.
+ -1 1 automatic (default) to let solver decide
+ 0 1 disable flow cover cuts
+ 1 1 enable flow cover cuts
 mip_implied_bound_cuts integer 0 -1 -1 1 1 3 Controls whether to enable implied bound cuts (-1 auto/default, 0 off, >0 on)
 mip_clique_cuts integer 0 -1 -1 1 1 3 Controls whether to enable clique cuts (-1 auto/default, 0 off, >0 on).
 mip_objective_step boolean 0 0 1 3 Controls whether cuOpt automatically detects and exploits discrete step structure in objective to tighten dual bound (0 off, 1 on/default).
@@ -113,17 +120,17 @@ mip_hyper_heuristic_enabled_recombiners integer 0 15 0 maxint 1 3 Controls bitma
 mip_hyper_heuristic_cycle_detection_length integer 0 30 0 maxint 1 3 Controls FP assignment cycle ring buffer
 mip_hyper_heuristic_relaxed_lp_time_limit double 0 1 0 maxdouble 1 3 Controls base relaxed LP time cap in heuristics
 mip_hyper_heuristic_related_vars_time_limit double 0 30 0 maxdouble 1 3 Controls time for related-variable structure build
-mip_hyper_diving_line_search
-mip_hyper_diving_pseudocost
-mip_hyper_diving_guided
-mip_hyper_diving_coefficient
-mip_hyper_diving_farkas
-mip_hyper_diving_vector_length
-mip_hyper_diving_min_node_depth
-mip_hyper_diving_node_limit
-mip_hyper_diving_iteration_limit_factor
-mip_hyper_diving_backtrack_limit
-mip_hyper_diving_show_type
+mip_hyper_diving_line_search integer 0 -1 -1 1 1 3 Controls diving heuristic line search (-1 automatic, 0 disabled, 1 enabled)
+mip_hyper_diving_pseudocost integer 0 -1 -1 1 1 3 Controls diving heuristic pseudocost (-1 automatic, 0 disabled, 1 enabled)
+mip_hyper_diving_guided integer 0 -1 -1 1 1 3 Controls diving heuristic guided diving (-1 automatic, 0 disabled, 1 enabled)
+mip_hyper_diving_coefficient integer 0 -1 -1 1 1 3 Controls diving heuristic coefficient (-1 automatic, 0 disabled, 1 enabled)
+mip_hyper_diving_farkas integer 0 -1 -1 1 1 3 Controls diving heuristic farkas (-1 automatic, 0 disabled, 1 enabled)
+mip_hyper_diving_vector_length integer 0 -1 -1 1 1 3 Controls diving heuristic vector-length (-1 automatic, 0 disabled, 1 enabled)
+mip_hyper_diving_min_node_depth integer 0 10 0 maxint 1 3 Controls minimum depth at which to start diving
+mip_hyper_diving_node_limit integer 0 500 0 maxint 1 3 Controls nodes explored per dive
+mip_hyper_diving_iteration_limit_factor double 0 0.05 0 1 1 3 Fraction of best-first iterations allowed per dive
+mip_hyper_diving_backtrack_limit integer 0 5 0 maxint 1 3 Controls maximum backtracking allowed per dive
+mip_hyper_diving_show_type boolean 0 0 1 3 log diving heuristic type when it finds a new incumbent
 mip_semicontinuous_big_m double 0 0 0 maxdouble 1 3 Controls the Big-M coefficient used when linearizing semi-continuous variable constraints
 
 *

--- a/build-link.sh
+++ b/build-link.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Exit immediately if a command exits with a non-zero status
+set -e 
+
+# 1. Define Paths (Configurable via Environment Variables)
+# Users can export these before running the script, otherwise defaults are used.
+GAMSDIST="${GAMSDIST:-$HOME/gamsdist}"
+WORKSPACE="${WORKSPACE:-$(pwd)}"
+CUOPT_VERSION="${CUOPT_VERSION:-26.06}"
+CUOPT_HASH="${CUOPT_HASH:-12345}"
+
+# 2. Dynamically find the site-packages directory to avoid hardcoding the Python version
+SITE_PACKAGES=$(find "$WORKSPACE/venv/lib" -maxdepth 2 -type d -name "site-packages" | head -n 1)
+
+if [ -z "$SITE_PACKAGES" ]; then
+    echo "Error: Could not find site-packages in $WORKSPACE/venv/lib."
+    echo "Please ensure you have created the virtual environment and installed dependencies."
+    exit 1
+fi
+
+# 3. Export specific build paths
+export GAMSCAPI="$GAMSDIST/apifiles/C/api"
+export CUOPT="$SITE_PACKAGES/libcuopt"
+export JITLINK="$SITE_PACKAGES/nvidia/cu13/lib"
+
+echo "Building GAMS cuOpt solver link..."
+echo "Using GAMSDIST: $GAMSDIST"
+echo "Using SITE_PACKAGES: $SITE_PACKAGES"
+
+# 4. Compile the solver link
+gcc -g3 -O0 -Wall gmscuopt.c -o gmscuopt-cu13.out \
+    -DCUOPT_VERSION=\"$CUOPT_VERSION\" \
+    -DCUOPT_HASH=\"$CUOPT_HASH\" \
+    -I "$GAMSCAPI" "$GAMSCAPI/gmomcc.c" "$GAMSCAPI/optcc.c" "$GAMSCAPI/gevmcc.c" \
+    -I "$CUOPT/include" "$JITLINK/libnvJitLink.so.13" \
+    -L "$CUOPT/lib64" -lcuopt
+
+# 5. Patch RPATH
+patchelf --set-rpath \$ORIGIN gmscuopt-cu13.out
+
+# 6. Move output and copy dependencies
+echo "Copying binaries and dependencies to $GAMSDIST..."
+
+# Create target directory if it doesn't exist
+mkdir -p "$GAMSDIST"
+
+mv gmscuopt-cu13.out "$GAMSDIST/gmscuopt.out"
+
+cp "$CUOPT/lib64/libcuopt.so" "$GAMSDIST/"
+cp "$SITE_PACKAGES"/libcuopt_cu13.libs/libgomp-*.so.1.0.0 "$GAMSDIST/"
+cp "$SITE_PACKAGES"/libcuopt_cu13.libs/libtbb-*.so.2 "$GAMSDIST/"
+cp "$SITE_PACKAGES"/libcuopt_cu13.libs/libtbbmalloc-*.so.2 "$GAMSDIST/"
+cp "$SITE_PACKAGES"/rapids_logger/lib64/librapids_logger.so "$GAMSDIST/"
+cp "$SITE_PACKAGES"/librmm/lib64/librmm.so "$GAMSDIST/"
+cp "$SITE_PACKAGES"/nvidia/cu13/lib/libcudss.so.0 "$GAMSDIST/"
+cp "$SITE_PACKAGES"/nvidia/cu13/lib/libcudss_mtlayer_gomp.so.0 "$GAMSDIST/"
+cp "$SITE_PACKAGES"/nvidia/cu13/lib/libnvJitLink.so.13 "$GAMSDIST/"
+cp "$SITE_PACKAGES"/nvidia/cu13/lib/libcublas.so.13 "$GAMSDIST/"
+cp "$SITE_PACKAGES"/nvidia/cu13/lib/libcublasLt.so.13 "$GAMSDIST/"
+cp "$SITE_PACKAGES"/nvidia/cu13/lib/libcurand.so.10 "$GAMSDIST/"
+cp "$SITE_PACKAGES"/nvidia/cu13/lib/libcusolver.so.12 "$GAMSDIST/"
+cp "$SITE_PACKAGES"/nvidia/cu13/lib/libcusparse.so.12 "$GAMSDIST/"
+cp "$SITE_PACKAGES"/libcuopt_cu13.libs/libcares-*.so.2.2.0 "$GAMSDIST/"
+
+# Copy assets (suppress errors if directory is empty or missing)
+cp -r assets/* "$GAMSDIST/" 2>/dev/null || true
+
+echo "Build and copy completed successfully."

--- a/examples/models/cuopt.opt
+++ b/examples/models/cuopt.opt
@@ -1,0 +1,5 @@
+method 1
+pdlp_solver_mode 1
+mip_scaling 2
+pdlp_precision 1
+mip_implied_bound_cuts 1

--- a/examples/models/flowshop.gms
+++ b/examples/models/flowshop.gms
@@ -1,0 +1,75 @@
+$title Flow Shop Scheduling - (FLOWSHOP,SEQ=376)
+
+$onText
+A workshop that produces metal pipes on demand for automotive industry
+has three machines for bending the pipes, soldering the fastenings,
+and assembling the links. The workshop has to produce six items, for
+which the durations of the processing steps are given below. Once
+started, jobs must be carried out to completion, but the
+workpieces(items) may wait between the machines.
+
+Every machine only processes one item at a time. A workpiece(item) may
+not overtake any other.
+
+What is the sequence that minimizes the total time for completing all
+items (makespan)?
+
+
+Gueret, C, Prins, C, and Sevaux, M, Applications of Optimization with
+Xpress-MP, Translated and revised by Susanne Heipcke. Dash
+Optimization, 2002.
+
+Keywords: mixed integer linear programming, relaxed mixed integer programming,
+          scenario analysis, GUSS, flow shop scheduling, production planning
+$offText
+
+Set
+   i 'item'    / i1*i6 /
+   m 'machine' / bending, soldering, assembly /;
+
+$set lastrank    i6
+$set lastmachine assembly
+
+Table proctime(m,i)
+              i1   i2   i3   i4   i5   i6
+   bending     3    6    3    5    5    7
+   soldering   5    4    2    4    4    5
+   assembly    5    2    4    6    3    6;
+
+Alias (i,k);
+
+Variable
+   rank(i,k)  'item i has position k'
+   start(m,k) 'start time for job in position k on m'
+   comp(m,k)  'completion time for job in postion k on m'
+   totwait    'time before first job + times between jobs on last machine';
+
+Binary   Variable rank;
+Positive Variable start, comp;
+
+Equation
+   oneInPosition(k) 'every position gets a jobs'
+   oneRankPer(i)    'every job is assigned a rank'
+   onmachrel(m,k)   'relations between the end of job rank k on machine m and start of job rank k on machine m+1'
+   permachrel(m,k)  'relations between the end of job rank k on machine m and start of job rank k+1 on machine m'
+   defcomp(m,k)     'calculation of completetion time based on start time and proctime'
+   defobj           'completion time of job rank last';
+
+oneInPosition(k)..  sum(i, rank(i,k)) =e= 1;
+
+oneRankPer(i)..     sum(k, rank(i,k)) =e= 1;
+
+onmachrel(m,k+1)..  start(m,k+1) =g= comp(m,k);
+
+permachrel(m+1,k).. start(m+1,k) =g= comp(m,k);
+
+defcomp(m,k)..      comp(m,k) =e= start(m,k) + sum(i, proctime(m,i)*rank(i,k));
+
+defobj..            totwait =g= comp('%lastmachine%','%lastrank%');
+
+Model sequence / all /;
+
+option optCr = 0;
+
+*sequence.optfile = 1;
+solve sequence using mip min totwait;

--- a/examples/models/knapsack.gms
+++ b/examples/models/knapsack.gms
@@ -1,0 +1,15 @@
+set i /i1*i4/;
+parameter
+    weights(i) /i1 3, i2 4, i3 8, i4 10/
+    utilities(i) /i1 3, i2 4, i3 8, i4 10/;
+scalar capacity /3/;
+binary variable x(i);
+free variable z;
+equation obj, cap;
+obj .. z =e= sum(i, utilities(i)*x(i));
+cap .. sum(i, x(i)*weights(i)) =l= capacity;
+x.l(i) = 0;
+x.l('i1') = 1;
+model m /all/;
+*m.optfile=1;
+solve m maximizing z using mip;

--- a/examples/models/miqcp.gms
+++ b/examples/models/miqcp.gms
@@ -1,0 +1,45 @@
+$title Simple MIQCP Example
+
+Set 
+    i 'Available items or assets' / 1*3 /;
+
+Alias (i,j);
+
+Parameter
+    c(i) 'Linear objective coefficients (e.g., expected return)' 
+         / 1 5, 2 8, 3 10 /
+    Q(i,j) 'Quadratic constraint coefficients (e.g., covariance matrix)' ;
+
+* Initialize Q as an identity matrix for simplicity (diagonal elements = 1)
+Q(i,j)$(ord(i) = ord(j)) = 1;
+
+Variables
+    x(i) 'Decision variables (quantity of items to select)'
+    z    'Objective variable (total return)';
+
+Integer Variable x;
+
+* It is good practice to bound integer variables
+x.up(i) = 5;
+
+Equations
+    obj_eq   'Objective function to maximize'
+    quad_eq  'Quadratic constraint (e.g., risk limit)'
+    lin_eq   'Linear constraint (e.g., total budget or item limit)';
+
+* Maximize linear return
+obj_eq..  z =e= sum(i, c(i)*x(i));
+
+* Subject to a quadratic constraint
+* Notice the multiplication of two variables: x(i) * x(j)
+quad_eq.. sum((i,j), x(i)*Q(i,j)*x(j)) =l= 50;
+
+* Subject to a linear constraint
+lin_eq..  sum(i, x(i)) =l= 10;
+
+Model simple_miqcp /all/;
+
+* Specify the model type explicitly as MIQCP
+Solve simple_miqcp using miqcp maximizing z;
+
+Display x.l, z.l;

--- a/examples/models/qcp.gms
+++ b/examples/models/qcp.gms
@@ -1,0 +1,25 @@
+Variables
+    x   'decision variable x'
+    y   'decision variable y'
+    obj 'objective variable'
+;
+
+Equations
+    objective    'minimize x + y'
+    constraint1  'linear lower bound'
+    constraint2  'quadratic upper bound'
+;
+
+objective..    obj =e= x + y;
+
+constraint1..  x + y =g= -5;
+
+* Note: You can use x**2 or sqr(x); QCP solvers accept both perfectly.
+constraint2..  2*sqr(x) + 2*x*y + 2*sqr(y) =l= 6;
+
+Model quadratic_problem /all/;
+
+* Simply change "nlp" to "qcp"
+Solve quadratic_problem minimizing obj using qcp;
+
+Display x.l, y.l, obj.l;

--- a/examples/models/qobj.gms
+++ b/examples/models/qobj.gms
@@ -1,0 +1,31 @@
+$Title Simple Quadratic Optimization Model (QCP)
+
+Variables
+    x1  "Decision variable 1"
+    x2  "Decision variable 2"
+    z   "Objective function value";
+
+Positive Variable x2;
+
+Equations
+    obj   "Objective function to minimize"
+    eq1   "Constraint x1 + x2 >= 5";
+
+* Define the equations
+obj.. z =e= sqr(x1) + 4*sqr(x2) - 8*x1 - 16*x2;
+
+eq1.. x1 + x2 =g= 5;
+
+* Set specific bounds for the variables
+x1.lo = 3;
+x1.up = 10;
+x2.up = 10;
+
+* Define the model including all equations
+Model myModel /all/;
+
+* Solve the model using a Quadratically Constrained Program (QCP) solver
+Solve myModel using qcp minimizing z;
+
+* Display the final values of the variables
+Display x1.l, x2.l, z.l;

--- a/examples/models/semicont.gms
+++ b/examples/models/semicont.gms
@@ -1,0 +1,27 @@
+$Title Small Semi-Continuous Variable Example
+
+Sets
+   i 'Products' / A, B /;
+
+Parameters
+   profit(i)    'Profit per unit'        / A 5, B 4 /
+   min_prod(i)  'Minimum batch if active'/ A 3, B 4 /
+   max_prod(i)  'Maximum production limit'/ A 8, B 8 /;
+
+SemiCont Variable x(i) 'Production quantity';
+Free Variable     z    'Total profit';
+
+x.lo(i) = min_prod(i);
+x.up(i) = max_prod(i);
+
+Equations
+   obj       'Objective function: maximize total profit'
+   capacity  'Total factory capacity limit';
+
+obj..       z =e= sum(i, profit(i) * x(i));
+
+capacity..  sum(i, x(i)) =l= 10;
+
+Model FactoryModel /all/;
+Solve FactoryModel using mip maximizing z;
+Display x.l, z.l;

--- a/examples/models/trnsport.gms
+++ b/examples/models/trnsport.gms
@@ -1,0 +1,72 @@
+$title A Transportation Problem (TRNSPORT,SEQ=1)
+
+$onText
+This problem finds a least cost shipping schedule that meets
+requirements at markets and supplies at factories.
+
+
+Dantzig, G B, Chapter 3.3. In Linear Programming and Extensions.
+Princeton University Press, Princeton, New Jersey, 1963.
+
+This formulation is described in detail in:
+Rosenthal, R E, Chapter 2: A GAMS Tutorial. In GAMS: A User's Guide.
+The Scientific Press, Redwood City, California, 1988.
+
+The line numbers will not match those in the book because of these
+comments.
+
+Keywords: linear programming, transportation problem, scheduling
+$offText
+
+Set
+   i 'canning plants' / seattle,  san-diego /
+   j 'markets'        / new-york, chicago, topeka /;
+
+Parameter
+   a(i) 'capacity of plant i in cases'
+        / seattle    350
+          san-diego  600 /
+
+   b(j) 'demand at market j in cases'
+        / new-york   325
+          chicago    300
+          topeka     275 /;
+
+Table d(i,j) 'distance in thousands of miles'
+              new-york  chicago  topeka
+   seattle         2.5      1.7     1.8
+   san-diego       2.5      1.8     1.4;
+
+Scalar f 'freight in dollars per case per thousand miles' / 90 /;
+
+Parameter c(i,j) 'transport cost in thousands of dollars per case';
+c(i,j) = f*d(i,j)/1000;
+
+Variable
+   x(i,j) 'shipment quantities in cases'
+   z      'total transportation costs in thousands of dollars';
+
+Positive Variable x;
+
+Equation
+   cost      'define objective function'
+   supply(i) 'observe supply limit at plant i'
+   demand(j) 'satisfy demand at market j';
+
+cost..      z =e= sum((i,j), c(i,j)*x(i,j));
+
+supply(i).. sum(j, x(i,j)) =l= a(i);
+
+demand(j).. sum(i, x(i,j)) =g= b(j);
+
+Model transport / all /;
+
+x.l(i,j) = 23;
+supply.m(i) = 42;
+demand.m(j) = 42;
+cost.m = 42;
+
+*transport.optfile = 1;
+solve transport using lp minimizing z;
+
+display x.l, x.m;

--- a/examples/models/verify.sh
+++ b/examples/models/verify.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 
-# Define the array of GAMS model base names
-MODELS=("flowshop" "knapsack" "qcp" "qobj" "trnsport")
+MODELS=()
+# Loop through all .gms files in the current working directory
+for file in *.gms; do
+    # Check if the file actually exists (handles the case where no .gms files are present)
+    [ -e "$file" ] || continue
+    # Strip the '.gms' extension and append the base name to the array
+    MODELS+=("${file%.gms}")
+done
+# Optional: Print the array to verify it worked
+echo "Models found: ${MODELS[@]}"
 
 # Tolerance for floating point comparison
 TOLERANCE="0.0001"

--- a/examples/models/verify.sh
+++ b/examples/models/verify.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# Define the array of GAMS model base names
+MODELS=("flowshop" "knapsack" "qcp" "qobj" "trnsport")
+
+# Tolerance for floating point comparison
+TOLERANCE="0.0001"
+
+echo "Starting GAMS objective value validation..."
+echo "=========================================="
+
+for model in "${MODELS[@]}"; do
+    echo "Processing model: ${model}.gms"
+
+    # 1. Run the model with the cuopt solver
+    # We specify distinct output list files (o=...) so we can parse them
+    echo "  -> Solving with cuopt..."
+    gams "${model}.gms" \
+         gdx="${model}_cuopt.gdx" \
+         o="${model}_cuopt.lst" \
+         lp=cuopt \
+         mip=cuopt \
+         qcp=cuopt \
+         > "${model}_cuopt.log" 2>&1
+
+    # 2. Run the model with the cplex solver
+    echo "  -> Solving with cplex..."
+    gams "${model}.gms" \
+         gdx="${model}_cplex.gdx" \
+         o="${model}_cplex.lst" \
+         lp=cplex \
+         mip=cplex \
+         qcp=cplex \
+         > "${model}_cplex.log" 2>&1
+
+    # 3. Extract the Objective Values from the .lst files
+    # We grab the last occurrence in case the model has multiple solves
+    obj_cuopt=$(grep "OBJECTIVE VALUE" "${model}_cuopt.lst" | tail -n 1 | awk '{print $NF}')
+    obj_cplex=$(grep "OBJECTIVE VALUE" "${model}_cplex.lst" | tail -n 1 | awk '{print $NF}')
+
+    # Check if we successfully extracted the values (handles solve failures)
+    if [ -z "$obj_cuopt" ] || [ -z "$obj_cplex" ]; then
+        echo "  [!] WARNING: Could not extract objective value for ${model}.gms."
+        echo "               cuopt obj: '${obj_cuopt}', cplex obj: '${obj_cplex}'"
+        echo "               Check the .lst or .log files."
+        echo "------------------------------------------"
+        continue
+    fi
+
+    # 4. Compare the objective values using awk (Bash doesn't do floats natively)
+    # Returns 1 if difference is greater than TOLERANCE, 0 otherwise
+    is_diff=$(awk -v v1="$obj_cuopt" -v v2="$obj_cplex" -v tol="$TOLERANCE" '
+        BEGIN {
+            diff = v1 - v2;
+            if (diff < 0) diff = -diff;
+            if (diff > tol) print 1;
+            else print 0;
+        }')
+
+    # 5. Check the comparison result and clean up on success
+    if [ "$is_diff" -eq 1 ]; then
+        echo "  [!] WARNING: Objectives differ!"
+        echo "               cuopt: $obj_cuopt"
+        echo "               cplex: $obj_cplex"
+        echo "               Files retained for debugging."
+    else
+        echo "  [✓] SUCCESS: Objective values match (cuopt: $obj_cuopt, cplex: $obj_cplex)."
+        echo "  -> Cleaning up generated files..."
+        
+        # Remove all generated files on success
+        rm -f "${model}_cuopt.gdx" "${model}_cplex.gdx"
+        rm -f "${model}_cuopt.lst" "${model}_cplex.lst"
+        rm -f "${model}_cuopt.log" "${model}_cplex.log"
+    fi
+    echo "------------------------------------------"
+done
+
+echo "Validation complete."

--- a/gmscuopt.c
+++ b/gmscuopt.c
@@ -127,6 +127,10 @@ int main(int argc, char *argv[])
   gmoSolveStatSet(gmo, gmoSolveStat_Capability);
   gmoModelStatSet(gmo, gmoModelStat_NoSolutionReturned);
 
+  /* Activate Q-mode for QCP and MIQCP models */
+  if (gmoModelType(gmo) == gmoProc_qcp || gmoModelType(gmo) == gmoProc_miqcp)
+    gmoUseQSet(gmo, 1);
+
   cuOptOptimizationProblem problem = NULL;
   cuOptSolverSettings settings = NULL;
   cuOptSolution solution = NULL;
@@ -577,7 +581,13 @@ int main(int argc, char *argv[])
         {
           q_row[k] = (cuopt_int_t)temp_q_row[k];
           q_col[k] = (cuopt_int_t)temp_q_col[k];
-          q_coef[k] = (cuopt_float_t)temp_q_coef[k];
+
+          // GAMS provides hessian matrix. Diagonal elements must be halved!
+          if (q_row[k] == q_col[k])
+            q_coef[k] = (cuopt_float_t)(temp_q_coef[k] / 2.0);
+          // non-diagonal elements can be passed through directly to cuOpt
+          else
+            q_coef[k] = (cuopt_float_t)temp_q_coef[k];
         }
 
         status = cuOptAddQuadraticConstraint(

--- a/gmscuopt.c
+++ b/gmscuopt.c
@@ -515,12 +515,6 @@ int main(int argc, char *argv[])
       goto DONE;
     }
 
-    status = gmoGetRhs(gmo, rhs);
-    if (status) {
-      printOut(gev, "gmoGetRhs failed. Status: %d\n", status);
-      goto DONE;
-    }
-
     status = cuOptCreateProblem(
         num_linear_constraints, // Use mapped linear size
         num_variables,
@@ -777,65 +771,67 @@ int main(int argc, char *argv[])
       mip_trace_line('E', 0, 1, total_elapsed, objective_value, solution_bound);
     }
 
-    int presolve, dual_postsolve;
+    cuopt_int_t presolve = 0, dual_postsolve = 0;
     cuOptGetIntegerParameter(settings, "presolve", &presolve);
     cuOptGetIntegerParameter(settings, "dual_postsolve", &dual_postsolve);
 
-    // Check if we should extract duals
-    if ((gmoModelType(gmo) != gmoProc_mip && gmoModelType(gmo) != gmoProc_miqcp) && !has_integer_vars && (!presolve || dual_postsolve))
-    {
-      status = cuOptGetReducedCosts(solution, objective_coefficients); // reuse n-vector
-      if (status != CUOPT_SUCCESS)
-      {
-        printOut(gev, "Error getting reduced cost: %d\n", status);
-        goto DONE;
-      }
-      if (gmoSense(gmo) == gmoObj_Max)
-      { // patch duals for max problem
-        for (int j = 0; j < num_variables; j++)
-        {
-          objective_coefficients[j] *= -1.0;
-        }
-      }
-      gmoSetVarM(gmo, objective_coefficients);
+    int is_qcp_model = gmoModelType(gmo) == gmoProc_qcp || gmoModelType(gmo) == gmoProc_miqcp;
 
-      // Extract duals using explicit mapping array
-      cuopt_float_t *raw_duals = malloc(num_constraints * sizeof(cuopt_float_t));
-      status = cuOptGetDualSolution(solution, raw_duals);
-      if (status != CUOPT_SUCCESS)
-      {
-        printOut(gev, "Error getting dual solution: %d\n", status);
-        free(raw_duals);
-        goto DONE;
-      }
-
-      double *final_duals = malloc(num_constraints * sizeof(double));
-      for (int i = 0; i < num_constraints; i++)
-      {
-        if (gams2cuopt_row)
+    // Only extract duals, when it's neither MIP nor QCP
+    // cuOpt doesn't support duals for QCP for now
+    if (!is_qcp_model && gmoModelType(gmo) != gmoProc_mip && !has_integer_vars && (!presolve || dual_postsolve)) {
+        status = cuOptGetReducedCosts(solution, objective_coefficients); // reuse n-vector
+        if (status != CUOPT_SUCCESS)
         {
-          final_duals[i] = raw_duals[gams2cuopt_row[i]];
+          printOut(gev, "Error getting reduced cost: %d\n", status);
+          goto DONE;
         }
-        else
-        {
-          final_duals[i] = raw_duals[i]; // Fallback if directly read from MPS
-        }
-
         if (gmoSense(gmo) == gmoObj_Max)
-        {
-          final_duals[i] *= -1.0; // patch duals for max problem
+        { // patch duals for max problem
+          for (int j = 0; j < num_variables; j++)
+          {
+            objective_coefficients[j] *= -1.0;
+          }
         }
+        gmoSetVarM(gmo, objective_coefficients);
+
+        // Extract duals using explicit mapping array
+        cuopt_float_t *raw_duals = malloc(num_constraints * sizeof(cuopt_float_t));
+        status = cuOptGetDualSolution(solution, raw_duals);
+        if (status != CUOPT_SUCCESS)
+        {
+          printOut(gev, "Error getting dual solution: %d\n", status);
+          free(raw_duals);
+          goto DONE;
+        }
+
+        double *final_duals = malloc(num_constraints * sizeof(double));
+        for (int i = 0; i < num_constraints; i++)
+        {
+          if (gams2cuopt_row)
+          {
+            final_duals[i] = raw_duals[gams2cuopt_row[i]];
+          }
+          else
+          {
+            final_duals[i] = raw_duals[i]; // Fallback if directly read from MPS
+          }
+
+          if (gmoSense(gmo) == gmoObj_Max)
+          {
+            final_duals[i] *= -1.0; // patch duals for max problem
+          }
+        }
+        gmoSetEquM(gmo, final_duals);
+        free(raw_duals);
+        free(final_duals);
       }
-      gmoSetEquM(gmo, final_duals);
-      free(raw_duals);
-      free(final_duals);
+      else
+      {
+        gmoSetHeadnTail(gmo, gmoHmarginals, 0.0); // no duals for mip
+      }
+      gmoCompleteSolution(gmo);
     }
-    else
-    {
-      gmoSetHeadnTail(gmo, gmoHmarginals, 0.0); // no duals for mip
-    }
-    gmoCompleteSolution(gmo);
-  }
   else if (fp_mip_trace) // gmoModelStat(gmo) == gmoModelStat_NoSolutionReturned
   {
     double total_elapsed = (gevTimeJNow(gev) - context.tstart) * 3600.0 * 24.0;

--- a/gmscuopt.c
+++ b/gmscuopt.c
@@ -537,6 +537,53 @@ int main(int argc, char *argv[])
       goto DONE;
     }
 
+    if (is_qcp)
+    {
+      int obj_qnz = gmoObjQNZ(gmo);
+      if (obj_qnz > 0)
+      {
+        int *temp_q_row = malloc(obj_qnz * sizeof(int));
+        int *temp_q_col = malloc(obj_qnz * sizeof(int));
+        double *temp_q_coef = malloc(obj_qnz * sizeof(double));
+
+        // Extract the quadratic objective coefficients from GAMS
+        gmoGetObjQ(gmo, temp_q_row, temp_q_col, temp_q_coef);
+
+        cuopt_int_t *q_row = malloc(obj_qnz * sizeof(cuopt_int_t));
+        cuopt_int_t *q_col = malloc(obj_qnz * sizeof(cuopt_int_t));
+        cuopt_float_t *q_coef = malloc(obj_qnz * sizeof(cuopt_float_t));
+
+        for (int k = 0; k < obj_qnz; k++)
+        {
+          q_row[k] = (cuopt_int_t)temp_q_row[k];
+          q_col[k] = (cuopt_int_t)temp_q_col[k];
+
+          // GAMS provides hessian matrix. Diagonal elements must be halved!
+          if (q_row[k] == q_col[k])
+            q_coef[k] = (cuopt_float_t)(temp_q_coef[k] / 2.0);
+          // Non-diagonal elements can be passed through directly to cuOpt
+          else
+            q_coef[k] = (cuopt_float_t)temp_q_coef[k];
+        }
+
+        // Apply the quadratic terms to the objective using the cuOpt API
+        status = cuOptSetQuadraticObjective(problem, obj_qnz, q_row, q_col, q_coef);
+
+        free(temp_q_row);
+        free(temp_q_col);
+        free(temp_q_coef);
+        free(q_row);
+        free(q_col);
+        free(q_coef);
+
+        if (status != CUOPT_SUCCESS)
+        {
+          printOut(gev, "Error setting quadratic objective: %d\n", status);
+          goto DONE;
+        }
+      }
+    }
+
     // Append the quadratic constraints dynamically
     for (int i = 0; i < num_constraints; i++)
     {

--- a/gmscuopt.c
+++ b/gmscuopt.c
@@ -87,7 +87,7 @@ int main(int argc, char *argv[])
   }
 
   gevGetStrOpt(gev, gevNameSysDir, filename);
-  strcat(filename, "optcuopt.def");  
+  strcat(filename, "optcuopt.def");
   if (optReadDefinition(opt, filename)) {
     for (int i=1; i<=optMessageCount(opt); i++) {
       int msg_type=0;
@@ -116,14 +116,14 @@ int main(int argc, char *argv[])
       }
     }
     optClearMessages(opt);
-    optEchoSet(opt, 0);    
-  } 
-          
+    optEchoSet(opt, 0);
+  }
+
   gmoObjStyleSet(gmo, gmoObjType_Fun);
   gmoIndexBaseSet(gmo, 0);
   gmoPinfSet(gmo, CUOPT_INFINITY);
   gmoMinfSet(gmo, -CUOPT_INFINITY);
-  gmoSetNRowPerm(gmo); 
+  gmoSetNRowPerm(gmo);
   gmoSolveStatSet(gmo, gmoSolveStat_Capability);
   gmoModelStatSet(gmo, gmoModelStat_NoSolutionReturned);
 
@@ -145,6 +145,12 @@ int main(int argc, char *argv[])
   cuopt_float_t* upper_bounds=NULL;
   char* constraint_sense=NULL;
   char* variable_types=NULL;
+
+  // QCP specific mapping arrays
+  int *gams2cuopt_row = NULL;
+  cuopt_float_t *orig_rhs = NULL;
+  char *orig_sense = NULL;
+
   int has_integer_vars = 0;
   fln_mip_trace[0] = '\0';
   sl_state_t context;
@@ -160,7 +166,7 @@ int main(int argc, char *argv[])
   // Setup miptrace facility if option is enabled
   if (optGetDefinedStr(opt, "miptrace"))
   {
-    if (gmoModelType(gmo) == gmoProc_mip)
+    if (gmoModelType(gmo) == gmoProc_mip || gmoModelType(gmo) == gmoProc_miqcp)
     {
       optGetStrStr(opt, "miptrace", fln_mip_trace);
       char sval2[256];
@@ -171,7 +177,7 @@ int main(int argc, char *argv[])
       }
     }
     else
-      printOut(gev, "WARNING: Enabling a MIP trace is only allowed for model type MIP!\n");
+      printOut(gev, "WARNING: Enabling a MIP trace is only allowed for model type MIP/MIQCP!\n");
   }
   if (fp_mip_trace)
   {
@@ -188,9 +194,9 @@ int main(int argc, char *argv[])
 
   // Check for MIP start feature
   mipstart = optGetIntStr(opt, "mipstart");
-  if(mipstart && gmoModelType(gmo) != gmoProc_mip)
+  if (mipstart && (gmoModelType(gmo) != gmoProc_mip && gmoModelType(gmo) != gmoProc_miqcp))
   {
-    printOut(gev, "WARNING: Setting a MIP start is only allowed for model type MIP!\n");
+    printOut(gev, "WARNING: Setting a MIP start is only allowed for model type MIP/MIQCP!\n");
     mipstart = 0;
   }
 
@@ -217,7 +223,8 @@ int main(int argc, char *argv[])
       goto DONE;
     }
   }
-  if (gmoModelType(gmo) == gmoProc_mip) {
+  if (gmoModelType(gmo) == gmoProc_mip || gmoModelType(gmo) == gmoProc_miqcp)
+  {
     status = cuOptSetFloatParameter(settings, CUOPT_MIP_ABSOLUTE_GAP, gevGetDblOpt(gev, gevOptCA));
     if (status != CUOPT_SUCCESS) {
       printOut(gev, "Error setting absolute gap: %d\n", status);
@@ -314,17 +321,64 @@ int main(int argc, char *argv[])
     }
   }
 
-  if (!optGetDefinedStr(opt, "prob_read")) {
-    constraint_matrix_row_offsets = malloc((num_constraints+1)*sizeof(cuopt_int_t));
-    constraint_matrix_column_indices = malloc(nnz*sizeof(cuopt_int_t));
-    constraint_matrix_coefficent_values = malloc(nnz*sizeof(cuopt_float_t));
-    objective_coefficients = malloc((num_variables)*sizeof(cuopt_float_t));
-    rhs = malloc((num_constraints)*sizeof(cuopt_float_t));
-    lower_bounds = malloc((num_variables)*sizeof(cuopt_float_t));
-    upper_bounds = malloc((num_variables)*sizeof(cuopt_float_t));
-    constraint_sense = malloc((num_constraints)*sizeof(char));
-    variable_types = malloc((num_variables)*sizeof(char));
-  
+  if (!optGetDefinedStr(opt, "prob_read"))
+  {
+    int is_qcp = (gmoModelType(gmo) == gmoProc_qcp || gmoModelType(gmo) == gmoProc_miqcp);
+    int num_linear_constraints = 0;
+    int num_quad_constraints = 0;
+
+    gams2cuopt_row = malloc(num_constraints * sizeof(int));
+    orig_rhs = malloc(num_constraints * sizeof(cuopt_float_t));
+    orig_sense = malloc(num_constraints * sizeof(char));
+
+    // First pass: Count linear vs quadratic and build index mapping
+    for (int i = 0; i < num_constraints; i++)
+    {
+      int qnz = 0;
+      if (is_qcp)
+      {
+        qnz = gmoGetRowQNZOne(gmo, i);
+        if (qnz < 0)
+          qnz = 0; // clamp -1 to 0
+      }
+
+      if (qnz == 0)
+      {
+        gams2cuopt_row[i] = num_linear_constraints++;
+      }
+      else
+      {
+        num_quad_constraints++;
+      }
+    }
+
+    // Append quadratic constraint indices sequentially
+    int q_idx = num_linear_constraints;
+    for (int i = 0; i < num_constraints; i++)
+    {
+      int qnz = 0;
+      if (is_qcp)
+      {
+        qnz = gmoGetRowQNZOne(gmo, i);
+        if (qnz < 0)
+          qnz = 0; // clamp -1 to 0
+      }
+      if (qnz > 0)
+      {
+        gams2cuopt_row[i] = q_idx++;
+      }
+    }
+
+    constraint_matrix_row_offsets = malloc((num_linear_constraints + 1) * sizeof(cuopt_int_t));
+    constraint_matrix_column_indices = malloc(nnz * sizeof(cuopt_int_t));
+    constraint_matrix_coefficent_values = malloc(nnz * sizeof(cuopt_float_t));
+    objective_coefficients = malloc((num_variables) * sizeof(cuopt_float_t));
+    rhs = malloc((num_linear_constraints) * sizeof(cuopt_float_t));
+    lower_bounds = malloc((num_variables) * sizeof(cuopt_float_t));
+    upper_bounds = malloc((num_variables) * sizeof(cuopt_float_t));
+    constraint_sense = malloc((num_linear_constraints) * sizeof(char));
+    variable_types = malloc((num_variables) * sizeof(char));
+
     if ((constraint_matrix_row_offsets == NULL) ||
         (constraint_matrix_column_indices == NULL) ||
         (constraint_matrix_coefficent_values == NULL) ||
@@ -337,64 +391,119 @@ int main(int argc, char *argv[])
       printOut(gev, "Could not allocate arrays\n");
       goto DONE;
     }
-  
-    status = gmoGetEquType(gmo, constraint_matrix_row_offsets); // use constraint_matrix_row_offsets as temp array
-    if (status) {
+
+    int *temp_equ_types = malloc(num_constraints * sizeof(int));
+    status = gmoGetEquType(gmo, temp_equ_types);
+    if (status)
+    {
       printOut(gev, "gmoGetEquType failed. Status: %d\n", status);
+      free(temp_equ_types);
       goto DONE;
     }
 
-    for (int i=0; i<num_constraints; i++) {
-      switch (constraint_matrix_row_offsets[i]) {
-         case gmoequ_E: constraint_sense[i] = CUOPT_EQUAL; break;
-         case gmoequ_L: constraint_sense[i] = CUOPT_LESS_THAN; break;
-         case gmoequ_G: constraint_sense[i] = CUOPT_GREATER_THAN; break;
-         default: printOut(gev, "Known row type %d\n", constraint_matrix_row_offsets[i]);
+    for (int i = 0; i < num_constraints; i++)
+    {
+      switch (temp_equ_types[i])
+      {
+      case gmoequ_E:
+        orig_sense[i] = CUOPT_EQUAL;
+        break;
+      case gmoequ_L:
+        orig_sense[i] = CUOPT_LESS_THAN;
+        break;
+      case gmoequ_G:
+        orig_sense[i] = CUOPT_GREATER_THAN;
+        break;
+      default:
+        printOut(gev, "Known row type %d\n", temp_equ_types[i]);
       }
     }
+    free(temp_equ_types);
 
-    status = gmoGetVarType(gmo, constraint_matrix_column_indices); // use constraint_matrix_column_indices as temp array
-    if (status) {
+    int *temp_var_types = malloc(num_variables * sizeof(int));
+    status = gmoGetVarType(gmo, temp_var_types);
+    if (status)
+    {
       printOut(gev, "gmoGetVarType failed. Status: %d\n", status);
+      free(temp_var_types);
       goto DONE;
     }
 
-    for (int j=0; j<num_variables; j++) {
-      switch (constraint_matrix_column_indices[j]) {
-         case gmovar_X: variable_types[j] = CUOPT_CONTINUOUS; break;
-         case gmovar_B:
-         case gmovar_I:
-           variable_types[j] = CUOPT_INTEGER;
-           has_integer_vars = 1;
-           break;
-         default: printOut(gev, "Known variable type %d\n", constraint_matrix_column_indices[j]);
+    for (int j = 0; j < num_variables; j++)
+    {
+      switch (temp_var_types[j])
+      {
+      case gmovar_X:
+        variable_types[j] = CUOPT_CONTINUOUS;
+        break;
+      case gmovar_B:
+      case gmovar_I:
+        variable_types[j] = CUOPT_INTEGER;
+        has_integer_vars = 1;
+        break;
+      case gmovar_SC:
+        variable_types[j] = CUOPT_SEMI_CONTINUOUS;
+        has_integer_vars = 1;
+        break;
+      default:
+        printOut(gev, "Known variable type %d\n", temp_var_types[j]);
       }
     }
+    free(temp_var_types);
 
     status = gmoGetVarLower(gmo, lower_bounds);
-    if (status) {
+    if (status)
+    {
       printOut(gev, "gmoGetVarLower failed. Status: %d\n", status);
       goto DONE;
     }
 
     status = gmoGetVarUpper(gmo, upper_bounds);
-    if (status) {
+    if (status)
+    {
       printOut(gev, "gmoGetVarUpper failed. Status: %d\n", status);
       goto DONE;
     }
 
-    nnz = 0;
-    for (int i=0; i<num_constraints; i++) {
-      int rnz=0, rnlnz=0;
-      constraint_matrix_row_offsets[i] = nnz;
-      status = gmoGetRowSparse(gmo, i, constraint_matrix_column_indices + nnz, constraint_matrix_coefficent_values + nnz, NULL, &rnz, &rnlnz);
-      if (status) {
-        printOut(gev, "gmoGetRowSparse %d failed. Status: %d\n", i, status);
-        goto DONE;
-      }
-      nnz += rnz;
+    status = gmoGetRhs(gmo, orig_rhs);
+    if (status)
+    {
+      printOut(gev, "gmoGetRhs failed. Status: %d\n", status);
+      goto DONE;
     }
-    constraint_matrix_row_offsets[num_constraints] = nnz;
+
+    nnz = 0;
+    int lin_row = 0;
+    for (int i = 0; i < num_constraints; i++)
+    {
+      int qnz = 0;
+      if (is_qcp)
+      {
+        qnz = gmoGetRowQNZOne(gmo, i);
+        if (qnz < 0)
+          qnz = 0; // clamp -1 to 0
+      }
+
+      // Pack ONLY purely linear constraints
+      if (qnz == 0)
+      {
+        constraint_matrix_row_offsets[lin_row] = nnz;
+        int rnz = 0, rnlnz = 0;
+        status = gmoGetRowSparse(gmo, i, constraint_matrix_column_indices + nnz, constraint_matrix_coefficent_values + nnz, NULL, &rnz, &rnlnz);
+        if (status)
+        {
+          printOut(gev, "gmoGetRowSparse %d failed. Status: %d\n", i, status);
+          goto DONE;
+        }
+
+        constraint_sense[lin_row] = orig_sense[i];
+        rhs[lin_row] = orig_rhs[i];
+
+        nnz += rnz;
+        lin_row++;
+      }
+    }
+    constraint_matrix_row_offsets[num_linear_constraints] = nnz;
 
     status = gmoGetObjVector(gmo, objective_coefficients, NULL);
     if (status) {
@@ -409,27 +518,95 @@ int main(int argc, char *argv[])
     }
 
     status = cuOptCreateProblem(
-      num_constraints,
-      num_variables,
-      (gmoSense(gmo)==gmoObj_Min)?CUOPT_MINIMIZE:CUOPT_MAXIMIZE,
-      gmoObjConst(gmo),
-      objective_coefficients,
-      constraint_matrix_row_offsets,
-      constraint_matrix_column_indices,
-      constraint_matrix_coefficent_values,
-      constraint_sense,
-      rhs,
-      lower_bounds,
-      upper_bounds,
-      variable_types,
-      &problem
-    );
+        num_linear_constraints, // Use mapped linear size
+        num_variables,
+        (gmoSense(gmo) == gmoObj_Min) ? CUOPT_MINIMIZE : CUOPT_MAXIMIZE,
+        gmoObjConst(gmo),
+        objective_coefficients,
+        constraint_matrix_row_offsets,
+        constraint_matrix_column_indices,
+        constraint_matrix_coefficent_values,
+        constraint_sense,
+        rhs,
+        lower_bounds,
+        upper_bounds,
+        variable_types,
+        &problem);
 
-    if (status != CUOPT_SUCCESS) {
-      printOut(gev, "Error creating problem from GAMS model: %d\n", status);
+    if (status != CUOPT_SUCCESS)
+    {
+      printOut(gev, "Error creating linear base problem from GAMS model: %d\n", status);
       goto DONE;
     }
-  } else {
+
+    // Append the quadratic constraints dynamically
+    for (int i = 0; i < num_constraints; i++)
+    {
+      int qnz = 0;
+      if (is_qcp)
+      {
+        qnz = gmoGetRowQNZOne(gmo, i);
+        if (qnz < 0)
+          qnz = 0; // clamp -1 to 0
+      }
+
+      if (qnz > 0)
+      {
+        int lin_nz = 0, rnlnz = 0;
+        int *temp_lin_cols = malloc(num_variables * sizeof(int));
+        double *temp_lin_vals = malloc(num_variables * sizeof(double));
+        gmoGetRowSparse(gmo, i, temp_lin_cols, temp_lin_vals, NULL, &lin_nz, &rnlnz);
+
+        cuopt_int_t *lin_cols = malloc(lin_nz * sizeof(cuopt_int_t));
+        cuopt_float_t *lin_vals = malloc(lin_nz * sizeof(cuopt_float_t));
+        for (int k = 0; k < lin_nz; k++)
+        {
+          lin_cols[k] = (cuopt_int_t)temp_lin_cols[k];
+          lin_vals[k] = (cuopt_float_t)temp_lin_vals[k];
+        }
+
+        int *temp_q_row = malloc(qnz * sizeof(int));
+        int *temp_q_col = malloc(qnz * sizeof(int));
+        double *temp_q_coef = malloc(qnz * sizeof(double));
+        gmoGetRowQ(gmo, i, temp_q_row, temp_q_col, temp_q_coef);
+
+        cuopt_int_t *q_row = malloc(qnz * sizeof(cuopt_int_t));
+        cuopt_int_t *q_col = malloc(qnz * sizeof(cuopt_int_t));
+        cuopt_float_t *q_coef = malloc(qnz * sizeof(cuopt_float_t));
+        for (int k = 0; k < qnz; k++)
+        {
+          q_row[k] = (cuopt_int_t)temp_q_row[k];
+          q_col[k] = (cuopt_int_t)temp_q_col[k];
+          q_coef[k] = (cuopt_float_t)temp_q_coef[k];
+        }
+
+        status = cuOptAddQuadraticConstraint(
+            problem,
+            qnz, q_row, q_col, q_coef,
+            lin_nz, lin_cols, lin_vals,
+            orig_sense[i], orig_rhs[i]);
+
+        free(temp_lin_cols);
+        free(temp_lin_vals);
+        free(lin_cols);
+        free(lin_vals);
+        free(temp_q_row);
+        free(temp_q_col);
+        free(temp_q_coef);
+        free(q_row);
+        free(q_col);
+        free(q_coef);
+
+        if (status != CUOPT_SUCCESS)
+        {
+          printOut(gev, "Error adding quadratic constraint %d: %d\n", i, status);
+          goto DONE;
+        }
+      }
+    }
+  }
+  else
+  {
     status = cuOptReadProblem(optGetStrStr(opt, "prob_read", filename), &problem);
     if (status != CUOPT_SUCCESS) {
       printOut(gev, "Error creating problem from MPS file: %d\n", status);
@@ -512,41 +689,43 @@ int main(int argc, char *argv[])
   gmoModelStatSet(gmo, gmoModelStat_NoSolutionReturned);
   if (!optGetDefinedStr(opt, "prob_read")) {
     switch (termination_status) {
-      case CUOPT_TERMINATION_STATUS_OPTIMAL:
-        gmoModelStatSet(gmo, gmoModelStat_OptimalGlobal);
-        break;
-      case CUOPT_TERMINATION_STATUS_INFEASIBLE:
-        gmoModelStatSet(gmo, gmoModelStat_InfeasibleGlobal);
-        break;
-      case CUOPT_TERMINATION_STATUS_UNBOUNDED:
-        gmoModelStatSet(gmo, gmoModelStat_Unbounded);
-        break;
-      case CUOPT_TERMINATION_STATUS_ITERATION_LIMIT:
-        gmoSolveStatSet(gmo, gmoSolveStat_Iteration);
-        break;
-      case CUOPT_TERMINATION_STATUS_TIME_LIMIT:
-        gmoSolveStatSet(gmo, gmoSolveStat_Resource);
-        break;
-      case CUOPT_TERMINATION_STATUS_NUMERICAL_ERROR:
-        gmoSolveStatSet(gmo, gmoSolveStat_SolverErr);
-        break;
-      case CUOPT_TERMINATION_STATUS_PRIMAL_FEASIBLE:
-        if (gmoModelType(gmo) == gmoProc_mip && has_integer_vars) {
-          gmoModelStatSet(gmo, gmoModelStat_Integer);
+    case CUOPT_TERMINATION_STATUS_OPTIMAL:
+      gmoModelStatSet(gmo, gmoModelStat_OptimalGlobal);
+      break;
+    case CUOPT_TERMINATION_STATUS_INFEASIBLE:
+      gmoModelStatSet(gmo, gmoModelStat_InfeasibleGlobal);
+      break;
+    case CUOPT_TERMINATION_STATUS_UNBOUNDED:
+      gmoModelStatSet(gmo, gmoModelStat_Unbounded);
+      break;
+    case CUOPT_TERMINATION_STATUS_ITERATION_LIMIT:
+      gmoSolveStatSet(gmo, gmoSolveStat_Iteration);
+      break;
+    case CUOPT_TERMINATION_STATUS_TIME_LIMIT:
+      gmoSolveStatSet(gmo, gmoSolveStat_Resource);
+      break;
+    case CUOPT_TERMINATION_STATUS_NUMERICAL_ERROR:
+      gmoSolveStatSet(gmo, gmoSolveStat_SolverErr);
+      break;
+    case CUOPT_TERMINATION_STATUS_PRIMAL_FEASIBLE:
+      if ((gmoModelType(gmo) == gmoProc_mip || gmoModelType(gmo) == gmoProc_miqcp) && has_integer_vars)
+      {
+        gmoModelStatSet(gmo, gmoModelStat_Integer);
         } else {
-          gmoModelStatSet(gmo, gmoModelStat_Feasible);
-        }
-        break;
-      case CUOPT_TERMINATION_STATUS_FEASIBLE_FOUND:
-        if (gmoModelType(gmo) == gmoProc_mip && has_integer_vars) {
-          gmoModelStatSet(gmo, gmoModelStat_Integer);
+        gmoModelStatSet(gmo, gmoModelStat_Feasible);
+      }
+      break;
+    case CUOPT_TERMINATION_STATUS_FEASIBLE_FOUND:
+      if ((gmoModelType(gmo) == gmoProc_mip || gmoModelType(gmo) == gmoProc_miqcp) && has_integer_vars)
+      {
+        gmoModelStatSet(gmo, gmoModelStat_Integer);
         } else {
-          gmoModelStatSet(gmo, gmoModelStat_Feasible);
-        }
-        break;
-      case CUOPT_TERMINATION_STATUS_UNBOUNDED_OR_INFEASIBLE:
-      default:
-        gmoSolveStatSet(gmo, gmoSolveStat_Solver);
+        gmoModelStatSet(gmo, gmoModelStat_Feasible);
+      }
+      break;
+    case CUOPT_TERMINATION_STATUS_UNBOUNDED_OR_INFEASIBLE:
+    default:
+      gmoSolveStatSet(gmo, gmoSolveStat_Solver);
     }
   }
 
@@ -565,7 +744,8 @@ int main(int argc, char *argv[])
     }
     gmoSetHeadnTail(gmo, gmoHobjval, objective_value);
 
-    if (gmoModelType(gmo) == gmoProc_mip && has_integer_vars) {
+    if ((gmoModelType(gmo) == gmoProc_mip || gmoModelType(gmo) == gmoProc_miqcp) && has_integer_vars)
+    {
       status = cuOptGetSolutionBound(solution, &solution_bound);
       if (status != CUOPT_SUCCESS) {
         printOut(gev, "Error getting solution bound: %d\n", status);
@@ -590,46 +770,73 @@ int main(int argc, char *argv[])
     int presolve, dual_postsolve;
     cuOptGetIntegerParameter(settings, "presolve", &presolve);
     cuOptGetIntegerParameter(settings, "dual_postsolve", &dual_postsolve);
-    if (gmoModelType(gmo) != gmoProc_mip && !has_integer_vars && (!presolve || dual_postsolve) ) {
+
+    // Check if we should extract duals
+    if ((gmoModelType(gmo) != gmoProc_mip && gmoModelType(gmo) != gmoProc_miqcp) && !has_integer_vars && (!presolve || dual_postsolve))
+    {
       status = cuOptGetReducedCosts(solution, objective_coefficients); // reuse n-vector
-      if (status != CUOPT_SUCCESS) {
+      if (status != CUOPT_SUCCESS)
+      {
         printOut(gev, "Error getting reduced cost: %d\n", status);
         goto DONE;
       }
-      if (gmoSense(gmo) == gmoObj_Max) { // patch duals for max problem
-        for (int j=0; j<num_variables; j++) {
+      if (gmoSense(gmo) == gmoObj_Max)
+      { // patch duals for max problem
+        for (int j = 0; j < num_variables; j++)
+        {
           objective_coefficients[j] *= -1.0;
         }
       }
       gmoSetVarM(gmo, objective_coefficients);
 
-      status = cuOptGetDualSolution(solution, rhs); // reuse m-vector
-      if (status != CUOPT_SUCCESS) {
-        printOut(gev, "Error getting reduced cost: %d\n", status);
+      // Extract duals using explicit mapping array
+      cuopt_float_t *raw_duals = malloc(num_constraints * sizeof(cuopt_float_t));
+      status = cuOptGetDualSolution(solution, raw_duals);
+      if (status != CUOPT_SUCCESS)
+      {
+        printOut(gev, "Error getting dual solution: %d\n", status);
+        free(raw_duals);
         goto DONE;
       }
-      if (gmoSense(gmo) == gmoObj_Max) { // patch duals for max problem
-        for (int i=0; i<num_constraints; i++) {
-          rhs[i] *= -1.0;
+
+      double *final_duals = malloc(num_constraints * sizeof(double));
+      for (int i = 0; i < num_constraints; i++)
+      {
+        if (gams2cuopt_row)
+        {
+          final_duals[i] = raw_duals[gams2cuopt_row[i]];
+        }
+        else
+        {
+          final_duals[i] = raw_duals[i]; // Fallback if directly read from MPS
+        }
+
+        if (gmoSense(gmo) == gmoObj_Max)
+        {
+          final_duals[i] *= -1.0; // patch duals for max problem
         }
       }
-      gmoSetEquM(gmo, rhs);
-    } else {
-      gmoSetHeadnTail(gmo, gmoHmarginals, 0.0); // no duals for mip      
+      gmoSetEquM(gmo, final_duals);
+      free(raw_duals);
+      free(final_duals);
+    }
+    else
+    {
+      gmoSetHeadnTail(gmo, gmoHmarginals, 0.0); // no duals for mip
     }
     gmoCompleteSolution(gmo);
   }
   else if (fp_mip_trace) // gmoModelStat(gmo) == gmoModelStat_NoSolutionReturned
   {
-      double total_elapsed = (gevTimeJNow(gev) - context.tstart) * 3600.0 * 24.0;
-      solution_bound = GMS_SV_NA;
-      if (gmoModelType(gmo) == gmoProc_mip && has_integer_vars)
-      {
-        status = cuOptGetSolutionBound(solution, &solution_bound);
-        if (status != CUOPT_SUCCESS)
-          solution_bound = GMS_SV_NA;
-      }
-      mip_trace_line('E', 0, 0, total_elapsed, GMS_SV_NA, solution_bound);
+    double total_elapsed = (gevTimeJNow(gev) - context.tstart) * 3600.0 * 24.0;
+    solution_bound = GMS_SV_NA;
+    if ((gmoModelType(gmo) == gmoProc_mip || gmoModelType(gmo) == gmoProc_miqcp) && has_integer_vars)
+    {
+      status = cuOptGetSolutionBound(solution, &solution_bound);
+      if (status != CUOPT_SUCCESS)
+        solution_bound = GMS_SV_NA;
+    }
+    mip_trace_line('E', 0, 0, total_elapsed, GMS_SV_NA, solution_bound);
   }
   status = gmoUnloadSolutionLegacy(gmo);
   if (status) {
@@ -651,7 +858,12 @@ DONE:
   free(constraint_sense);
   free(variable_types);
 
-  if(fp_mip_trace)
+  // Free dynamically mapped structures
+  free(gams2cuopt_row);
+  free(orig_rhs);
+  free(orig_sense);
+
+  if (fp_mip_trace)
     mip_trace_close();
 
 GAMSDONE:
@@ -696,7 +908,7 @@ int mip_trace_close()
 #define bnd_na(x) x == GMS_SV_NA || x == HUGE_VAL || x == -HUGE_VAL
 
 int mip_trace_line(char seriesID, double node, int giveint,
-                    double seconds, double bestint, double bestbnd)
+                   double seconds, double bestint, double bestbnd)
 {
   int rc;
 


### PR DESCRIPTION
Update the link to work with already released NVIDIA cuopt version 26.06.

Necessary changes to the link:
- [x] Support quadratic constraints and objectives via new C API
- [x] Support semi-continuous variables in MIP
- [x] Mirror option to limit MIP B&B node count and disable probing in MIP presolve

Version number for release is going to be v0.0.7